### PR TITLE
added scope resolution operator in Operators section in c++

### DIFF
--- a/cpp.md
+++ b/cpp.md
@@ -119,6 +119,7 @@ int a[2][3] = {
 | Assignment Operator|= , += , -= , *= , /= , %=, <<=, >>=, &=, ^=, `\|=` |
 | Ternary Operator| ? : |
 | sizeof operator| sizeof() |
+| Scope Resolution Operator| :: (used to reference the global variable or member function that is out of scope.) |
 
 ## Conditional Statements
 


### PR DESCRIPTION
scope resolution operator is used to reference the global variable or member function that is out of scope.