### PR TITLE
bash: Switch to different table markdown syntax

### DIFF
--- a/bash.md
+++ b/bash.md
@@ -1,9 +1,6 @@
----
-title: Bash shell
-description: Bourne-Again SHell, an `sh`-compatible command-line interpreter.
-created: 2021-12-19
-updated: 2021-12-19
----
+| Title      | Description                                                      | Created    | Updated    |
+| :--------- | :--------------------------------------------------------------- | :--------- | :--------- |
+| Bash shell | Bourne-Again SHell, an `sh`-compatible command-line interpreter. | 2021-12-19 | 2022-10-09 |
 
 ## Sample program
 


### PR DESCRIPTION
The previous table type was not able to format cell contents instead, it was showing raw text like `this`.  The newer table can do as intended.